### PR TITLE
Initial port of teensy-loader.js to node-usb's updated 2.x API.

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "intel-hex": "^0.1.1",
-    "usb": "^1.5.0"
+    "usb": "^2.1.3"
   },
   "devDependencies": {
     "@babel/cli": "^7.1.0",

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import usb from "usb";
+import { usb, findByIds } from "usb";
 import fs from "fs";
 import intel_hex from "intel-hex";
 
@@ -133,7 +133,7 @@ class TeensyLoader {
   ___open(vid, pid) {
     this.__close();
 
-    let device = usb.findByIds(vid, pid);
+    let device = findByIds(vid, pid);
 
     if (!device) return null;
 


### PR DESCRIPTION
@algernon - I don't have a way to test this locally. Can you please test it before merge? 

This is blocking the Kaleidoscope upgrade to Electron 17